### PR TITLE
Fix: gstreamer1.0-omx package url

### DIFF
--- a/meta-rzg2l/docs/template/conf/rzpi/site.conf
+++ b/meta-rzg2l/docs/template/conf/rzpi/site.conf
@@ -1,1 +1,0 @@
-MACHINE ??= "rzpi"

--- a/meta-rzg2l/docs/template/conf/rzpi/site.conf.sample
+++ b/meta-rzg2l/docs/template/conf/rzpi/site.conf.sample
@@ -1,0 +1,4 @@
+MACHINE ??= "rzpi"
+
+SRC_URI_remove_pn-gstreamer1.0-omx = "git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common"
+SRC_URI_pn-gstreamer1.0-omx = "git://github.com/GStreamer/common.git;destsuffix=git/common;name=common"


### PR DESCRIPTION
Changes include:
    - Override for SRC_URI in
      > meta-rz-codecs/recipes-multimedia/gstreamer/gstreamer1.0-omx_1.16.3.bbappend
      using site.conf. The default URL for gstreamer common project no
      longer works
      due to removal of git protocol.
      Repoint it to https://github.com/GStreamer/common
    - rename site.conf in template to site.conf.sample to fix site.conf not being copied to build/conf.

Notes:
	- Dunfell is EOL, so no use of patching it in the recipe.