### PR TITLE
rzpi: site.conf: set SRCREV to rz-sbc-qt-v1.0-rc1

### DIFF
--- a/meta-rzg2l/docs/template/conf/rzpi/site.conf.sample
+++ b/meta-rzg2l/docs/template/conf/rzpi/site.conf.sample
@@ -2,3 +2,20 @@ MACHINE ??= "rzpi"
 
 SRC_URI_remove_pn-gstreamer1.0-omx = "git://anongit.freedesktop.org/gstreamer/common;destsuffix=git/common;name=common"
 SRC_URI_pn-gstreamer1.0-omx = "git://github.com/GStreamer/common.git;destsuffix=git/common;name=common"
+
+# linux-renesas tagged: rz-sbc-qt-v1.0-rc1
+SRCREV_remove_pn-linux-renesas = "${AUTOREV}"
+SRCREV_pn-linux-renesas = "rz-sbc-qt-v1.0-rc1"
+
+# u-boot tagged: rz-sbc-qt-v1.0-rc1
+SRCREV_remove_pn-u-boot = "${AUTOREV}"
+SRC_URI_remove_pn-u-boot = "git://source.denx.de/u-boot/u-boot.git;protocol=https;branch=master"
+SRCREV_pn-u-boot = "rz-sbc-qt-v1.0-rc1"
+
+# trusted-firmware-a tagged: rz-sbc-qt-v1.0-rc1
+SRCREV_remove_pn-trusted-firmware-a = "${AUTOREV}"
+SRCREV_pn-trusted-firmware-a = "rz-sbc-qt-v1.0-rc1"
+
+# flash-writer tagged: rz-sbc-qt-v1.0-rc1
+SRCREV_remove_pn-flash-writer = "${AUTOREV}"
+SRCREV_pn-flash-writer = "rz-sbc-qt-v1.0-rc1"


### PR DESCRIPTION
It's easy to override SRCREV for linux-renesas, trusted-firmware-a, flash-writer. But when setting for u-boot, there is an issue that bitbake gets confused about which u-boot source is using (upstream repo and SST repo).
- upstream repo: source.denx.de/u-boot/u-boot.git
- SST repo: github.com/Renesas-SST/u-boot.git
```
FetchError: Fetcher failure: Unable to resolve 'rz-sbc-qt-v1.0-rc1' in upstream git repository in git ls-remote output for source.denx.de/u-boot/u-boot.git
```

We must remove the upstream repo which is not used in the build from the u-boot SRC_URI list.
