### PR TITLE
rz-sbc: pre-install python 3 libraries

### DIFF
--- a/meta-rzg2l/docs/template/conf/rzpi/local.conf.sample
+++ b/meta-rzg2l/docs/template/conf/rzpi/local.conf.sample
@@ -404,5 +404,11 @@ PACKAGECONFIG_append_pn-python3 = " tk"
 # Ignore vte-local-en-gb package because it has incompatible license GPL-3.0
 BAD_RECOMMENDATIONS += " vte-locale-en-gb"
 
+# Pre-installed Python libraries
+IMAGE_INSTALL_append = " python3-numpy"
+IMAGE_INSTALL_append = " python3-pandas"
+IMAGE_INSTALL_append = " python3-pyserial"
+IMAGE_INSTALL_append = " python3-matplotlib"
+
 # Add default apt configuration sources
 IMAGE_INSTALL_append += " apt-sources-config "


### PR DESCRIPTION
Hi @preetam-reddy,

This PR is for pre-installing new Python libraries.

Changes include:
- Pre-install numpy, pandas, pyserial, and matplotlib python 3 libraries by adding them to local.conf.sample
      
Here are the versions of each library:

```
root@rzpi:~# python3
>>> import pandas
>>> import serial
>>> import numpy
>>> import matplotlib
>>> print(serial.__version__)
3.4
>>> print(numpy.__version__)
1.17.4
>>> print(pandas.__version__)
1.0.5
>>> print(matplotlib.__version__)
3.2.1
```