### PR TITLE
eSDK enabled

### DIFF
--- a/meta-rzg2l/docs/recipes-docs/rzpi-docs/readme.bb
+++ b/meta-rzg2l/docs/recipes-docs/rzpi-docs/readme.bb
@@ -12,12 +12,16 @@ SRC_URI = " \
 COMPATIBLE_MACHINE = "(rzpi)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-FILES_${PN} += ""
-AKKOW_EMPTY_${PN} = "1"
+FILES_${PN} += "/docs"
 
-do_deploy () {
-	install -d ${DEPLOY_DIR_IMAGE}
-	install -m 0755 ${S}/README.md ${DEPLOY_DIR_IMAGE}
+do_install () {
+    install -d ${D}/docs
+    install -m 0644 ${S}/README.md ${D}/docs/README.md
 }
 
+do_deploy () {
+    install -m 0644 ${D}/docs/README.md ${DEPLOYDIR}
+}
+
+inherit deploy
 addtask deploy after do_install

--- a/meta-rzg2l/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/meta-rzg2l/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,0 +1,35 @@
+SUMMARY = "Client for Wi-Fi Protected Access (WPA)"
+HOMEPAGE = "http://w1.fi/wpa_supplicant/"
+DESCRIPTION = "wpa_supplicant is a WPA Supplicant for Linux, BSD, Mac OS X, and Windows with support for WPA and WPA2 (IEEE 802.11i / RSN). Supplicant is the IEEE 802.1X/WPA component that is used in the client stations. It implements key negotiation with a WPA Authenticator and it controls the roaming and IEEE 802.11 authentication/association of the wlan driver."
+
+# Overwrite the SYSTEMD_SERVICE
+SYSTEMD_SERVICE_${PN} = ""
+
+# Overwrite the installation of wpa_supplicant.service when installing on rootfs systemd and dbus
+# This action is considered as a work around to support eSDK build when eSDK do_sdk_depends task always
+# tries to point out a duplicate error of the wpa_supplicant.service installation in summit-supplicant-lwb and wpa-supplicant recipes
+# eventhough the fact is that the conflict is handled in summit-supplicant-lwb recipe.
+do_install () {
+    install -d ${D}${sbindir}
+    install -m 755 wpa_supplicant/wpa_supplicant ${D}${sbindir}
+    install -m 755 wpa_supplicant/wpa_cli        ${D}${sbindir}
+
+    install -d ${D}${bindir}
+    install -m 755 wpa_supplicant/wpa_passphrase ${D}${bindir}
+
+    install -d ${D}${docdir}/wpa_supplicant
+    install -m 644 wpa_supplicant/README ${WORKDIR}/wpa_supplicant.conf ${D}${docdir}/wpa_supplicant
+
+    install -d ${D}${sysconfdir}
+    install -m 600 ${WORKDIR}/wpa_supplicant.conf-sane ${D}${sysconfdir}/wpa_supplicant.conf
+
+    install -d ${D}${sysconfdir}/network/if-pre-up.d/
+    install -d ${D}${sysconfdir}/network/if-post-down.d/
+    install -d ${D}${sysconfdir}/network/if-down.d/
+    install -m 755 ${WORKDIR}/wpa-supplicant.sh ${D}${sysconfdir}/network/if-pre-up.d/wpa-supplicant
+    cd ${D}${sysconfdir}/network/ && \
+    ln -sf ../if-pre-up.d/wpa-supplicant if-post-down.d/wpa-supplicant
+
+    install -d ${D}/etc/default/volatiles
+    install -m 0644 ${WORKDIR}/99_wpa_supplicant ${D}/etc/default/volatiles
+}


### PR DESCRIPTION
Support eSDK build with some updates.

```
son@son-L509:~/data/work/vu/rz-build-scripts/rz-sbc/yocto_rzsbc_board/build/tmp/deploy/sdk$ ls -la
total 5636800
drwxr-xr-x 2 son son       4096 Thg 8  28 09:59 .
drwxr-xr-x 7 son son       4096 Thg 8  27 14:09 ..
-rw-r--r-- 1 son son       7034 Thg 8  28 02:34 poky-glibc-x86_64-core-image-qt-aarch64-rzpi-toolchain-ext-3.1.26.host.manifest
-rwxr-xr-x 2 son son 5744699444 Thg 8  28 02:34 poky-glibc-x86_64-core-image-qt-aarch64-rzpi-toolchain-ext-3.1.26.sh
-rw-r--r-- 1 son son      15663 Thg 8  28 02:34 poky-glibc-x86_64-core-image-qt-aarch64-rzpi-toolchain-ext-3.1.26.target.manifest
-rw-r--r-- 2 son son     547816 Thg 8  28 02:19 poky-glibc-x86_64-core-image-qt-aarch64-rzpi-toolchain-ext-3.1.26.testdata.json
-rw-r--r-- 2 son son       6300 Thg 8  27 14:07 x86_64-buildtools-nativesdk-standalone-3.1.26.host.manifest
-rwxr-xr-x 2 son son   26252567 Thg 8  27 14:09 x86_64-buildtools-nativesdk-standalone-3.1.26.sh
-rw-r--r-- 2 son son          0 Thg 8  27 14:07 x86_64-buildtools-nativesdk-standalone-3.1.26.target.manifest
-rw-r--r-- 2 son son     500199 Thg 8  27 14:06 x86_64-buildtools-nativesdk-standalone-3.1.26.testdata.json
```