### PR TITLE
rz-sbc: update documentation and rename the main user guide document

### DIFF
--- a/meta-rzg2l/docs/recipes-docs/rzpi-docs/rzpi-docs.bb
+++ b/meta-rzg2l/docs/recipes-docs/rzpi-docs/rzpi-docs.bb
@@ -8,7 +8,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 S = "${WORKDIR}"
 
 SRC_URI = " \
-    file://r12uz0158eu0100-rz-g2l-sbc-single-board-computer.pdf \
+    file://r12uz0158eu0101-rz-g2l-sbc-single-board-computer.pdf \
     file://RZG2L-SBC_Evaluation_license.pdf \
     file://Disclaimer051.pdf \
     file://Disclaimer052.pdf \
@@ -18,7 +18,7 @@ FILES_${PN} += "/util"
 
 do_install () {
     install -d ${D}/util
-    install -m 0644 ${S}/r12uz0158eu0100-rz-g2l-sbc-single-board-computer.pdf ${D}/util/r12uz0158eu0100-rz-g2l-sbc-single-board-computer.pdf
+    install -m 0644 ${S}/r12uz0158eu0101-rz-g2l-sbc-single-board-computer.pdf ${D}/util/r12uz0158eu0101-rz-g2l-sbc-single-board-computer.pdf
     install -m 0644 ${S}/RZG2L-SBC_Evaluation_license.pdf ${D}/util/RZG2L-SBC_Evaluation_license.pdf
 
     # Disclaimer files

--- a/meta-rzg2l/docs/recipes-docs/rzpi-readme/files/README.md
+++ b/meta-rzg2l/docs/recipes-docs/rzpi-readme/files/README.md
@@ -45,14 +45,16 @@ After preparing the host machine for building, download necessary packages (get 
 - Graphic: https://www.renesas.com/us/en/document/swo/rz-mpu-graphics-library-evaluation-version-rzg2l-and-rzg2lc-rtk0ef0045z13001zj-v112enzip
 - Codec: https://www.renesas.com/us/en/document/swo/rz-mpu-video-codec-library-evaluation-version-rzg2l-rtk0ef0045z15001zj-v110xxzip?r=1535641
 
-Then create a workspace folder (example: `~/Yocto`) for the build and put the downloaded packages and support script `rzsbc_yocto.sh` into it:
+Then create a workspace folder (example: `~/Yocto`) for the build and put the files `rzsbc_yocto.sh`, `site.conf`, `README.md`, `jq-linux-amd64` and a patch folder for eSDK build support from the release package into it.
 ```
 $ mkdir ~/Yocto
 $ cp *.zip ~/Yocto
 $ cp rzsbc_yocto.sh ~/Yocto
 $ cp site.conf ~/Yocto
-$ cp 0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch ~/Yocto
-
+$ cp README.md ~/Yocto
+$ cp jq-linux-amd64 ~/Yocto
+$ cp git_patch.json ~/Yocto
+$ cp -r patches ~/Yocto
 ```
 
 Step 3: Build package
@@ -79,6 +81,15 @@ rzpi
 │   │   ├── core-image-qt-rzpi.manifest -> core-image-qt-rzpi-20240717204209.rootfs.manifest
 │   │   └── core-image-qt-rzpi.testdata.json -> core-image-qt-rzpi-20240717204209.testdata.json
 │   ├── Readme.md
+│   ├── src                                                             <---- Build script packages
+│   │   ├── git_patch.json
+│   │   ├── jq-linux-amd64
+│   │   ├── patches
+│   │   │   ├── 0001-meta-classes-esdk-explicitly-address-the-location-of.patch
+│   │   │   └── 0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
+│   │   ├── README.md
+│   │   ├── rzsbc_yocto.sh
+│   │   └── site.conf
 │   └── tools
 │       ├── bootloader-flasher
 │       │   ├── linux                                                    <---- Bootloader flashing script package folder on Linux
@@ -179,6 +190,8 @@ rzpi
     │       ├── core-image-qt-rzpi.tar.bz2
     │       └── Readme.md
     └── Readme.md
+
+25 directories, 91 files
 ```
 
 ## Programming/Flashing images for RZG2L-SBC

--- a/meta-rzg2l/recipes-extend/host-readme/files/Readme.md
+++ b/meta-rzg2l/recipes-extend/host-readme/files/Readme.md
@@ -14,6 +14,13 @@ host
 │   ├── core-image-qt-rzpi.manifest -> core-image-qt-rzpi-20240717204209.rootfs.manifest        # Symlink to the root filesystem manifest
 │   └── core-image-qt-rzpi.testdata.json -> core-image-qt-rzpi-20240717204209.testdata.json     # Symlink to the test data JSON
 ├── Readme.md                                                                                   # This document
+├── src                                                                                         # Build script folder
+│   ├── git_patch.json
+│   ├── jq-linux-amd64
+│   ├── patches
+│   ├── README.md
+│   ├── rzsbc_yocto.sh
+│   └── site.conf
 └── tools/                                                                                      # Tools and scripts used for managing and flashing bootloaders and filesystems across different platforms
 ```
 


### PR DESCRIPTION
Changes include:
    - Updated the build hierarchy section and README.md in the host
      build folder to reflect the addition of a new `src` folder for the
      build script.
    - Renamed the main user guide document to
      `r12uz0158eu0101-rz-g2l-sbc-single-board-computer.pdf`
      
Here is the updated build hierarchy, with the addition of the host/src folder and the renamed user guide document.
```
.
├── host
│   ├── build
│   │   ├── core-image-qt-rzpi-20240913120921.rootfs.manifest
│   │   ├── core-image-qt-rzpi-20240913120921.testdata.json
│   │   ├── core-image-qt-rzpi.manifest -> core-image-qt-rzpi-20240913120921.rootfs.manifest
│   │   └── core-image-qt-rzpi.testdata.json -> core-image-qt-rzpi-20240913120921.testdata.json
│   ├── Readme.md
│   ├── src
│   │   ├── git_patch.json
│   │   ├── jq-linux-amd64
│   │   ├── patches
│   │   │   ├── 0001-meta-classes-esdk-explicitly-address-the-location-of.patch
│   │   │   └── 0001-rzsbc-summit-radio-pre-3.4-support-eSDK-build.patch
│   │   ├── README.md
│   │   ├── rzsbc_yocto.sh
│   │   └── site.conf
│   └── tools
│       ├── bootloader-flasher
│       │   ├── linux
│       │   │   ├── bootloader_flash.py
│       │   │   └── Readme.md
│       │   ├── Readme.md
│       │   └── windows
│       │       ├── config.ini
│       │       ├── flash_bootloader.bat
│       │       ├── Readme.md
│       │       └── tools
│       │           ├── cygterm.cfg
│       │           ├── flash_bootloader.ttl
│       │           ├── TERATERM.INI
│       │           ├── ttermpro.exe
│       │           ├── ttpcmn.dll
│       │           ├── ttpfile.dll
│       │           ├── ttpmacro.exe
│       │           ├── ttpset.dll
│       │           └── ttxssh.dll
│       ├── Readme.md
│       ├── sd-creator
│       │   ├── linux
│       │   │   ├── Readme.md
│       │   │   └── sd_flash.sh
│       │   ├── Readme.md
│       │   └── windows
│       │       ├── config.ini
│       │       ├── flash_filesystem.bat
│       │       ├── Readme.md
│       │       └── tools
│       │           ├── AdbWinApi.dll
│       │           ├── cygterm.cfg
│       │           ├── fastboot.bat
│       │           ├── fastboot.exe
│       │           ├── flash_system_image.ttl
│       │           ├── TERATERM.INI
│       │           ├── ttermpro.exe
│       │           ├── ttpcmn.dll
│       │           ├── ttpfile.dll
│       │           ├── ttpmacro.exe
│       │           ├── ttpset.dll
│       │           └── ttxssh.dll
│       └── uload-bootloader
│           ├── linux
│           │   ├── Readme.md
│           │   └── uload_bootloader_flash.py
│           ├── Readme.md
│           └── windows
│               ├── config.ini
│               ├── Readme.md
│               ├── tools
│               │   ├── cygterm.cfg
│               │   ├── TERATERM.INI
│               │   ├── ttermpro.exe
│               │   ├── ttpcmn.dll
│               │   ├── ttpfile.dll
│               │   ├── ttpmacro.exe
│               │   ├── ttpset.dll
│               │   ├── ttxssh.dll
│               │   └── uload-flash_bootloader.ttl
│               └── uload-flash_bootloader.bat
├── license
│   ├── Disclaimer051.pdf
│   └── Disclaimer052.pdf
├── r12uz0158eu0100-rz-g2l-sbc-single-board-computer.pdf
├── README.md
├── RZG2L-SBC_Evaluation_license.pdf
└── target
    ├── env
    │   ├── core-image-qt.env
    │   ├── Readme.md
    │   └── uEnv.txt
    ├── images
    │   ├── bl2_bp-rzpi.bin
    │   ├── bl2_bp-rzpi.srec
    │   ├── bl2-rzpi.bin
    │   ├── core-image-qt-rzpi.wic
    │   ├── dtbs
    │   │   ├── overlays
    │   │   │   ├── Readme.md
    │   │   │   ├── rzpi-can.dtbo
    │   │   │   ├── rzpi-dsi.dtbo
    │   │   │   ├── rzpi-ext-i2c.dtbo
    │   │   │   ├── rzpi-ext-spi.dtbo
    │   │   │   └── rzpi-ov5640.dtbo
    │   │   ├── Readme.md
    │   │   ├── rzpi--5.10.184-cip36+gitAUTOINC+5f065ec41b-r1-rzpi-20240913120921.dtb
    │   │   └── rzpi.dtb -> rzpi--5.10.184-cip36+gitAUTOINC+5f065ec41b-r1-rzpi-20240913120921.dtb
    │   ├── fip-rzpi.bin
    │   ├── fip-rzpi.srec
    │   ├── Flash_Writer_SCIF_rzpi.mot
    │   ├── Image -> Image--5.10.184-cip36+gitAUTOINC+5f065ec41b-r1-rzpi-20240913120921.bin
    │   ├── Image--5.10.184-cip36+gitAUTOINC+5f065ec41b-r1-rzpi-20240913120921.bin
    │   ├── Readme.md
    │   └── rootfs
    │       ├── core-image-qt-rzpi.tar.bz2
    │       └── Readme.md
    └── Readme.md

25 directories, 91 files
```