### PR TITLE
rz-sbc: qt: demo: update smarthome demo's URL

### DIFF
--- a/meta-rz-common/dynamic-layers/qt5-layer/demo/qtsmarthome_1.0.bbappend
+++ b/meta-rz-common/dynamic-layers/qt5-layer/demo/qtsmarthome_1.0.bbappend
@@ -1,0 +1,5 @@
+SUMMARY = "Qt5 smarthome QML demo application"
+DESCRIPTION = "This is the Smarthome QML demo application. It shows some user interfaces for controlling an automated house"
+
+# Override SRC_URI in meta-qt5 as the previous one at http://share.basyskom.com/demos/ is no longer accessible.
+SRC_URI = "https://artifacts.toradex.com/artifactory/tdxref-oe-prod-frankfurt/dunfell-5.x.y/release/4/sources/smarthome_src.tar.gz"


### PR DESCRIPTION
Update the URL of smarthome demo application due to the old one at: http://share.basyskom.com/demos/ is no longer accessible.

Related commit: https://github.com/meta-qt5/meta-qt5/commit/77b6060cef9337b184100083746c2e35f531be74