### PR TITLE
rz-common: gstreamer-omx: change submodule url

### DIFF
--- a/meta-rz-common/recipes-multimedia/gstreamer/gstreamer1.0-omx/0001-common-Change-the-submodule-to-a-mirror-repository.patch
+++ b/meta-rz-common/recipes-multimedia/gstreamer/gstreamer1.0-omx/0001-common-Change-the-submodule-to-a-mirror-repository.patch
@@ -1,0 +1,24 @@
+From e169fd99f959f8b99b0ee9352103e73d481d0696 Mon Sep 17 00:00:00 2001
+From: Tien Nguyen <tien.nguyen.uh@renesas.com>
+Date: Tue, 18 Mar 2025 09:24:40 +0000
+Subject: [PATCH] common: Change the submodule to a mirror repository
+
+Change the submodule to a mirror repository instead of freedesktop
+
+Signed-off-by: Tien Nguyen <tien.nguyen.uh@renesas.com>
+---
+ .gitmodules | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/.gitmodules b/.gitmodules
+index 0ab8387..75bb08c 100644
+--- a/.gitmodules
++++ b/.gitmodules
+@@ -1,3 +1,3 @@
+ [submodule "common"]
+ 	path = common
+-	url = https://gitlab.freedesktop.org/gstreamer/common.git
++	url = https://github.com/GStreamer/common.git
+-- 
+2.25.1
+

--- a/meta-rz-common/recipes-multimedia/gstreamer/gstreamer1.0-omx_%.bbappend
+++ b/meta-rz-common/recipes-multimedia/gstreamer/gstreamer1.0-omx_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}/:"
+
+SRC_URI_append = " \
+    file://0001-common-Change-the-submodule-to-a-mirror-repository.patch \
+"


### PR DESCRIPTION
Using a patch to change the submodule URL for gst-omx from https://gitlab.freedesktop.org/gstreamer/common.git to https://github.com/GStreamer/common.git