### PR TITLE
rz-cmn: Add recipes for binmake and platform-gen

### DIFF
--- a/include/core-image-renesas-base.inc
+++ b/include/core-image-renesas-base.inc
@@ -39,12 +39,13 @@ IMAGE_BOOT_FILES:rz-cmn = " \
     target/images/*.bin;uload-bootloader/ \
 "
 
-DEPENDS += " linux-yocto uenv firmware-pack"
+DEPENDS += " linux-yocto uenv firmware-pack platform-gen "
 
 add_bootloader_rootfs() {
     install -d ${IMAGE_ROOTFS}/boot/uload-bootloader
     cp -rf ${DEPLOY_DIR_IMAGE}/target/images/bl2_bp_*.bin ${IMAGE_ROOTFS}/boot/uload-bootloader
     cp -rf ${DEPLOY_DIR_IMAGE}/target/images/fip_*.bin ${IMAGE_ROOTFS}/boot/uload-bootloader
+    cp -rf ${DEPLOY_DIR_IMAGE}/target/images/*-platform-settings.bin ${IMAGE_ROOTFS}/boot/uload-bootloader
 }
 
 # Clean the output directory after the build

--- a/recipes-tools/binmake/binmake-native_1.0.bb
+++ b/recipes-tools/binmake/binmake-native_1.0.bb
@@ -1,0 +1,19 @@
+SUMMARY = "Binmake tool to create platform info binaries file"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+URL = "git://github.com/vudangRVC/rz-utility.git"
+BRANCH = "main"
+SRCREV = "${AUTOREV}"
+
+SRC_URI = "${URL};protocol=https;branch=${BRANCH}"
+
+S = "${WORKDIR}/git/tools/binmake"
+B = "${WORKDIR}/build"
+
+inherit cmake native
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/binmake ${D}${bindir}/binmake
+}

--- a/recipes-tools/binmake/files/platform_info.json
+++ b/recipes-tools/binmake/files/platform_info.json
@@ -1,0 +1,117 @@
+{
+    "rzg2l-evk": {
+        "model_id": 16,
+        "revision_minor": 1,
+        "revision_major": 20,
+        "model_string": "rz/g2l-evk",
+        "mfg_name": "Renesas",
+
+        "bl2_loc": 0,
+        "bl2_dtb_loc": 0,
+        "u_boot_loc": 3,
+        "u_boot_dtb_loc": 3,
+        "kernel_loc": 1,
+        "kernel_dtb_loc": 1,
+
+        "bl2_id": 10,
+        "bl2_dtb_id": 11,
+        "u_boot_id": 20,
+        "u_boot_dtb_id": 21,
+        "kernel_id": 30,
+        "kernel_dtb_id": 31,
+
+        "bl2_desc": ["11E00", "0"],
+        "bl2_dtb_desc": ["2C000"],
+        "u_boot_desc": ["0", "1D200"],
+        "u_boot_dtb_desc": ["0"],
+        "kernel_desc": ["0"],
+        "kernel_dtb_desc": ["48000000"]
+    },
+
+    "rzg2l-sbc": {
+        "model_id": 17,
+        "revision_minor": 1,
+        "revision_major": 20,
+        "model_string": "rz/g2l-sbc",
+        "mfg_name": "Renesas",
+
+        "bl2_loc": 0,
+        "bl2_dtb_loc": 0,
+        "u_boot_loc": 3,
+        "u_boot_dtb_loc": 3,
+        "kernel_loc": 1,
+        "kernel_dtb_loc": 1,
+
+        "bl2_id": 2,
+        "bl2_dtb_id": 3,
+        "u_boot_id": 6,
+        "u_boot_dtb_id": 7,
+        "kernel_id": 14,
+        "kernel_dtb_id": 15,
+
+        "bl2_desc": ["11E00", "0"],
+        "bl2_dtb_desc": ["2C000"],
+        "u_boot_desc": ["0", "1D200"],
+        "u_boot_dtb_desc": ["0"],
+        "kernel_desc": ["0"],
+        "kernel_dtb_desc": ["48000000"]
+    },
+
+    "rzv2l-evk": {
+        "model_id": 32,
+        "revision_minor": 1,
+        "revision_major": 20,
+        "model_string": "rz/v2l-evk",
+        "mfg_name": "Renesas",
+
+        "bl2_loc": 0,
+        "bl2_dtb_loc": 0,
+        "u_boot_loc": 3,
+        "u_boot_dtb_loc": 3,
+        "kernel_loc": 1,
+        "kernel_dtb_loc": 1,
+
+        "bl2_id": 2,
+        "bl2_dtb_id": 3,
+        "u_boot_id": 6,
+        "u_boot_dtb_id": 7,
+        "kernel_id": 14,
+        "kernel_dtb_id": 15,
+
+        "bl2_desc": ["11E00", "0"],
+        "bl2_dtb_desc": ["2C000"],
+        "u_boot_desc": ["0", "1D200"],
+        "u_boot_dtb_desc": ["0"],
+        "kernel_desc": ["0"],
+        "kernel_dtb_desc": ["48000000"]
+    },
+
+    "rzv2h-evk": {
+        "model_id": 48,
+        "revision_minor": 1,
+        "revision_major": 20,
+        "model_string": "rz/v2h-evk",
+        "mfg_name": "Renesas",
+
+        "bl2_loc": 0,
+        "bl2_dtb_loc": 0,
+        "u_boot_loc": 3,
+        "u_boot_dtb_loc": 3,
+        "kernel_loc": 1,
+        "kernel_dtb_loc": 1,
+
+        "bl2_id": 2,
+        "bl2_dtb_id": 3,
+        "u_boot_id": 6,
+        "u_boot_dtb_id": 7,
+        "kernel_id": 14,
+        "kernel_dtb_id": 15,
+
+        "bl2_desc": ["8101E00", "0"],
+        "bl2_dtb_desc": ["8163000"],
+        "u_boot_desc": ["0", "60000"],
+        "u_boot_dtb_desc": ["0"],
+        "kernel_desc": ["0"],
+        "kernel_dtb_desc": ["48000000"]
+    }
+}

--- a/recipes-tools/binmake/platform-gen.bb
+++ b/recipes-tools/binmake/platform-gen.bb
@@ -1,0 +1,32 @@
+SUMMARY = "Generate platform binary settings using binmake"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://platform_info.json"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+DEPENDS = "binmake-native"
+
+S = "${WORKDIR}/sources-unpack"
+
+inherit deploy
+
+# Create platform info file
+do_compile () {
+    for target in ${SUPPORT_TARGETS}; do
+        binmake --input=${S}/platform_info.json \
+                --board=${target} \
+                --output=${S}/${target}-platform-settings.bin
+    done
+}
+
+# Install platform info images to deploy folder
+do_deploy () {
+    # Create deploy folder
+    install -d ${DEPLOYDIR}/target/images
+    install -m 0644 ${S}/*.bin ${DEPLOYDIR}/target/images/
+}
+
+addtask deploy after do_compile before do_build
+
+COMPATIBLE_MACHINE = "rz-cmn"

--- a/recipes-tools/binmake/platform-gen.bb
+++ b/recipes-tools/binmake/platform-gen.bb
@@ -17,6 +17,8 @@ do_compile () {
         binmake --input=${S}/platform_info.json \
                 --board=${target} \
                 --output=${S}/${target}-platform-settings.bin
+
+        objcopy -I binary -O srec --adjust-vma=0x0000 --srec-forceS3 ${S}/${target}-platform-settings.bin ${S}/${target}-platform-settings.srec
     done
 }
 
@@ -24,6 +26,8 @@ do_compile () {
 do_deploy () {
     # Create deploy folder
     install -d ${DEPLOYDIR}/target/images
+
+    install -m 0644 ${S}/*.srec ${DEPLOYDIR}/target/images/
     install -m 0644 ${S}/*.bin ${DEPLOYDIR}/target/images/
 }
 


### PR DESCRIPTION
- Add binmake-native recipe to build the binmake tool for native use.
- Add platform-gen recipe to generate platform information from JSON.