### PR TITLE
rz-cmn-srp: Support common V4L2 initialization script

### DIFF
--- a/recipes-extend/v4l2-init/files/v4l2-init.sh
+++ b/recipes-extend/v4l2-init/files/v4l2-init.sh
@@ -1,16 +1,26 @@
-#!/bin/sh
+#!/bin/bash
 
 cru=$(cat /sys/class/video4linux/v4l-subdev*/name | grep "cru-ip")
 csi2=$(cat /sys/class/video4linux/v4l-subdev*/name | grep "csi2")
-valid_resolutions=("720x480" "720x576" "1024x768" "1280x720" "1920x1080" "2592x1944")
+ov=$(cat /sys/class/video4linux/v4l-subdev*/name | grep "ov")
+default_camera=$(echo "$ov" | awk '{print $1}')
+
+declare -A camera_default_resolution
+camera_default_resolution["ov5640"]="1280x720"
+camera_default_resolution["ov5645"]="1280x960"
+
+declare -A camera_valid_resolutions
+camera_valid_resolutions["ov5640"]="720x480 720x576 1024x768 1280x720 1920x1080 2592x1944"
+camera_valid_resolutions["ov5645"]="1280x960 1920x1080 2592x1944"
 
 # Usage information function
 function print_usage {
     echo "Usage: $0 <resolution>"
-    echo "Available resolutions for ov5640: ${valid_resolutions[@]}. \
-	Using default resolution '1280x720'."
+    echo "Detected camera: $default_camera"
+    echo "Available resolutions for $default_camera: ${camera_valid_resolutions[$default_camera]}"
+    echo ""
     echo "Example: $0 1920x1080"
-    echo "If no resolution is specified, the default resolution '1280x720' will be used."
+    echo "If no resolution is specified, $default_camera will used the default resolution '${camera_default_resolution[$default_camera]}'."
 }
 
 # Check if help is requested
@@ -21,15 +31,17 @@ fi
 
 # Check for no input
 if [ -z "$1" ]; then
-    echo "No resolution specified. Using default resolution: 1280x720"
-    ov5640_res="1280x720"
+    echo "Detected camera: $default_camera"
+    echo "No resolution specified. Using default resolution: ${camera_default_resolution[$default_camera]}"
+    ov564x_res="${camera_default_resolution[$default_camera]}"
 else
-    ov5640_res=$1
+    ov564x_res="$1"
+    valid_resolutions=(${camera_valid_resolutions[$default_camera]})
     # Check if the given resolution is valid
-    if [[ ! " ${valid_resolutions[@]} " =~ " ${ov5640_res} " ]]; then
-        echo "Invalid resolution: $ov5640_res"
-        ov5640_res="1280x720"
-        echo "Input resolution is not available. Using default resolution: 1280x720"
+    if [[ ! " ${valid_resolutions[@]} " =~ " ${ov564x_res} " ]]; then
+        echo "Invalid resolution: $ov564x_res for camera $default_camera"
+        ov564x_res="${camera_default_resolution[$default_camera]}"
+        echo "Input resolution is not available. Using default resolution: ${camera_default_resolution[$default_camera]}"
     fi
 fi
 
@@ -42,10 +54,15 @@ else
     then
         echo "No MIPI CSI2 sub video device founds"
     else
-        media-ctl -d /dev/media0 -V "'$csi2':1 [fmt:UYVY8_1X16/$ov5640_res field:none]"
-        media-ctl -d /dev/media0 -V "'ov5640 1-003c':0 [fmt:UYVY8_1X16/$ov5640_res field:none]"
-        media-ctl -d /dev/media0 -V "'$cru':0 [fmt:UYVY8_1X16/$ov5640_res field:none]"
-        media-ctl -d /dev/media0 -V "'$cru':1 [fmt:UYVY8_1X16/$ov5640_res field:none]"
-        echo "Link CRU/CSI2 to ov5640 1-003c with format UYVY8_1X16 and resolution $ov5640_res"
+        media-ctl -d /dev/media0 -V "'$csi2':0 [fmt:UYVY8_1X16/$ov564x_res field:none]"
+        media-ctl -d /dev/media0 -V "'$csi2':1 [fmt:UYVY8_1X16/$ov564x_res field:none]"
+        media-ctl -d /dev/media0 -V "'$ov':0 [fmt:UYVY8_1X16/$ov564x_res field:none]"
+        media-ctl -d /dev/media0 -V "'$cru':0 [fmt:UYVY8_1X16/$ov564x_res field:none]"
+        media-ctl -d /dev/media0 -V "'$cru':1 [fmt:UYVY8_1X16/$ov564x_res field:none]"
+
+        width=${ov564x_res%x*}
+        height=${ov564x_res#*x}
+        v4l2-ctl -d /dev/video0 --set-fmt-video=width=${width},height=${height},pixelformat=UYVY
+        echo "Link CRU/CSI2 to $ov with format UYVY8_1X16 and resolution ${ov564x_res}"
     fi
 fi


### PR DESCRIPTION
Change includes:
- Add support for the ov5645 camera sensor
- Support for 1280x960 resolution for the RZG2L-EVK, RZV2L-EVK and RZV2H-EVK
- Support common camera initialization script for all devices