### PR TITLE
recipes-bsp: flash-writer: modify build workspace

### DIFF
--- a/recipes-bsp/flash-writer/flash-writer.bb
+++ b/recipes-bsp/flash-writer/flash-writer.bb
@@ -19,7 +19,7 @@ inherit deploy
 #require include/provisioning.inc
 
 S = "${WORKDIR}/git"
-B = "${S}/../build"
+B = "${S}/../build/${DISTRO}"
 UNPACKDIR = "${S}"
 
 do_prepare_src() {


### PR DESCRIPTION
Update the flash-writer recipe to separate build workspace per DISTRO. This avoids stale artifacts and build failures when switching between different distros.)