### PR TITLE
rz-cmn: cleanup initramfs and enforce release_clean

### DIFF
--- a/conf/machine/rz-cmn.conf
+++ b/conf/machine/rz-cmn.conf
@@ -19,8 +19,8 @@ MACHINE_EXTRA_RRECOMMENDS += "kernel-modules"
 MACHINE_EXTRA_RRECOMMENDS += "linux-firmware-wl12xx linux-firmware-wl18xx linux-firmware-rtl-nic"
 
 # Use an initramfs and populate it with the kernel modules and key firmware
-INITRAMFS_IMAGE ?= "core-image-initramfs-boot"
-PACKAGE_INSTALL:append:pn-core-image-initramfs-boot = " ${MACHINE_EXTRA_RRECOMMENDS}"
+#INITRAMFS_IMAGE ?= "core-image-initramfs-boot"
+#PACKAGE_INSTALL:append:pn-core-image-initramfs-boot = " ${MACHINE_EXTRA_RRECOMMENDS}"
 
 IMAGE_FSTYPES ?= "wic wic.gz wic.bmap"
 WKS_FILE ?= "genericarm64.wks.in"

--- a/include/core-image-renesas-base.inc
+++ b/include/core-image-renesas-base.inc
@@ -197,3 +197,4 @@ IMAGE_INSTALL:append = " kernel-modules"
 
 # Force image rebuild before SDK creation (changes when building multiple images lead to re-deploy but not clean because images are not re-built)
 SDK_POSTPROCESS_COMMAND:prepend = " do_release_clean;"
+do_release_clean[nostamp] = "1"


### PR DESCRIPTION
- Mark release_clean as [nostamp] to ensure it runs every build.
- Remove initramfs image