### PR TITLE
recipes-kernel: add mmc0-1 aliases patch for all RZ/[V,G]2L platforms

### DIFF
--- a/recipes-kernel/linux/linux-yocto_6.10.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.10.bbappend
@@ -65,6 +65,7 @@ SRC_URI:append:rz-cmn = "\
 	file://common/0005-drm-renesas-rz-du-Add-missing-DSI-D-PHY-init.patch \
 	file://common/0006-media-rzg2l-cru-fix-retry-path-by-stopping-subdev-wi.patch \
 	file://common/0007-dts-renesas-add-I3C_SEL-macro-to-switch-between-I2C2.patch \
+	file://common/0008-arm64-dts-renesas-Add-mmc0-1-aliases-for-all-RZ-V-G-.patch \
 "
 
 KERNEL_FEATURES:append = " sii.cfg laird.cfg touch.cfg peripherals.cfg da7219.cfg drm_panel.cfg ov5640.cfg panfrost.cfg kernel-common.cfg ${@oe.utils.conditional('OPTIMIZE_KERN', '1', ' optimize.cfg', '', d)}"

--- a/recipes-kernel/linux/rz-cmn/common/0008-arm64-dts-renesas-Add-mmc0-1-aliases-for-all-RZ-V-G-.patch
+++ b/recipes-kernel/linux/rz-cmn/common/0008-arm64-dts-renesas-Add-mmc0-1-aliases-for-all-RZ-V-G-.patch
@@ -1,0 +1,37 @@
+From 13f5dc80d80061df3ceb0f3ffbeaa8bf06938ff3 Mon Sep 17 00:00:00 2001
+From: audang <au.dang.jx@renesas.com>
+Date: Fri, 16 May 2025 17:07:27 +0700
+Subject: [PATCH] arm64: dts: renesas: Add mmc0,1 aliases for all RZ/[V,G]2L
+ platforms
+
+Fix index of mmcblk devices:
+aliases {
+        mmc0 = &sdhi0;  /* mmcblk0 for eMMC */
+        mmc1 = &sdhi1;  /* mmcblk1 for uSD */
+};
+
+Upstream-Status: Pending
+
+Signed-off-by: Binh Nguyen <binh.nguyen.jz@renesas.com>
+Signed-off-by: hienhuynh <hien.huynh.px@renesas.com>
+Signed-off-by: Au Dang <au.dang.jx@renesas.com>
+---
+ arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi b/arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi
+index b7a3e6caa386..dad6e1260ceb 100644
+--- a/arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi
++++ b/arch/arm64/boot/dts/renesas/rz-smarc-common.dtsi
+@@ -26,6 +26,8 @@ aliases {
+ 		serial0 = &scif0;
+ 		i2c0 = &i2c0;
+ 		i2c1 = &i2c1;
++		mmc0 = &sdhi0;
++		mmc1 = &sdhi1;
+ 	};
+ 
+ 	chosen {
+-- 
+2.43.0
+


### PR DESCRIPTION
Add patch to fix index of mmcblk devices for all RZ/[V,G]2L platforms

```
aliases {
        mmc0 = &sdhi0;  /* mmcblk0 for eMMC */
        mmc1 = &sdhi1;  /* mmcblk1 for uSD */
};
```
