### PR TITLE
wic: increase boot partition alignment to 4096 sectors

### DIFF
--- a/wic/rz-cmn-image-bootpart-mmc0.wks
+++ b/wic/rz-cmn-image-bootpart-mmc0.wks
@@ -3,5 +3,5 @@
 # are located in the first vfat partition but not mounted. The second ext4 partition
 # will contain all boot files and boot environment file.
 
-part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 16 --fixed-size 200
+part --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 2048 --fixed-size 200
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 16 --overhead-factor 1.0


### PR DESCRIPTION
Reserve bootloader region (sectors 0-4095) for BL2, BID, and FIP components. This aligns with eSD boot mode sector allocations and prevents bootloader components from corrupting the boot partition.