### PR TITLE
rz-cmn: add open-source OP-TEE integration

### DIFF
--- a/conf/templates/rz-cmn/local.conf.sample
+++ b/conf/templates/rz-cmn/local.conf.sample
@@ -383,3 +383,9 @@ PREFERRED_VERSION_alsa-utils = "1.2.11"
 # with libgpiod 2.x. Forcing 1.6.5 avoids rootfs dependency resolution
 # issues caused by mixed libgpiod versions.
 PREFERRED_VERSION_libgpiod = "1.6.5"
+
+# OP-TEE is disabled by default. Enable this to build open-source OP-TEE
+# from Renesas-SST/rz_optee_os and include tee-supplicant in the image.
+# The recipe builds both G2L/V2L (g2l_smarc_2, CFG_DT=y) and V2H (v2h_evk_1,
+# CFG_DT=n) binaries in a single build run.
+# ENABLE_SPD_OPTEE = "1"

--- a/include/core-image-renesas-base.inc
+++ b/include/core-image-renesas-base.inc
@@ -28,6 +28,7 @@ IMAGE_INSTALL:append = " \
 "
 
 IMAGE_INSTALL:append:rz-cmn = " uenv"
+IMAGE_INSTALL:append:rz-cmn = " ${@oe.utils.conditional('ENABLE_SPD_OPTEE', '1', 'optee-client', '', d)}"
 
 WKS_FILE = "rz-cmn-image-bootpart-mmc0.wks"
 

--- a/recipes-bsp/optee/optee-client/optee.service
+++ b/recipes-bsp/optee/optee-client/optee.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OP-TEE Supplicant daemon
+After=dev-tee0.device
+Wants=dev-tee0.device
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/tee-supplicant
+Restart=on-failure
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-bsp/optee/optee-client_git.bb
+++ b/recipes-bsp/optee/optee-client_git.bb
@@ -1,0 +1,51 @@
+DESCRIPTION = "OP-TEE Client"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=69663ab153298557a59c67a60a743e5b"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+PV = "4.10.0+git${SRCPV}"
+BRANCH = "master"
+SRCREV = "9f5e90918093c1d1cd264d8149081b64ab7ba672"
+
+SRC_URI = " \
+    git://github.com/OP-TEE/optee_client.git;branch=${BRANCH};protocol=https \
+    file://optee.service \
+"
+
+DEPENDS += "util-linux"
+
+inherit python3native systemd
+
+SYSTEMD_SERVICE:${PN} = "optee.service"
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE = "RPMB_EMU=0 WITH_TEEACL=0"
+
+do_install() {
+    oe_runmake install \
+        DESTDIR=${D} \
+        SBINDIR=${sbindir} \
+        LIBDIR=${libdir} \
+        INCLUDEDIR=${includedir}
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/optee.service ${D}${systemd_system_unitdir}/optee.service
+}
+
+RPROVIDES:${PN} += "optee-client"
+FILES:${PN} += " \
+    ${sbindir}/tee-supplicant \
+    ${libdir}/libteec.so* \
+    ${libdir}/libckteec.so* \
+    ${libdir}/libseteec.so* \
+    ${systemd_system_unitdir}/optee.service \
+"
+FILES:${PN}-dev += " \
+    ${includedir}/tee_client_api.h \
+    ${includedir}/teec_trace.h \
+    ${includedir}/optee_client_config.mk \
+    ${libdir}/libteec.a \
+    ${libdir}/libckteec.a \
+    ${libdir}/libseteec.a \
+"

--- a/recipes-bsp/optee/optee-os_git.bb
+++ b/recipes-bsp/optee/optee-os_git.bb
@@ -1,0 +1,83 @@
+DESCRIPTION = "OP-TEE OS for Renesas RZ CMN"
+LICENSE = "BSD-2-Clause & BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c1f21c4f72f372ef38a5a4aee55ec173"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+DEPENDS = "python3-cryptography-native python3-pyelftools-native"
+
+require include/rz-optee-config.inc
+inherit deploy python3native
+
+PV = "4.10.0+git${SRCPV}"
+BRANCH = "styhead/rz-cmn"
+SRCREV = "${AUTOREV}"
+
+SRC_URI = "git://github.com/Renesas-SST/rz_optee_os.git;branch=${BRANCH};protocol=https"
+
+COMPATIBLE_MACHINE = "rz-cmn"
+S = "${WORKDIR}/git"
+
+PLATFORM = "rz"
+
+LD[unexport] = "1"
+LDFLAGS[unexport] = "1"
+libdir[unexport] = "1"
+
+export CROSS_COMPILE64 = "${TARGET_PREFIX}"
+CFLAGS:prepend = "--sysroot=${STAGING_DIR_HOST} "
+
+RZ_SCE = "${@oe.utils.conditional('ENABLE_RZ_SCE', '1', 'y', 'n', d)}"
+
+# Common make flags shared by both flavors
+OPTEE_COMMON_FLAGS = " \
+    PLATFORM=${PLATFORM} \
+    CFG_ARM64_core=y \
+    CFG_REE_FS=y \
+    CFG_RPMB_FS=n \
+    CFG_CRYPTO_WITH_CE=n \
+    CFG_RZ_SCE=${RZ_SCE} \
+    CROSS_COMPILE64=${TARGET_PREFIX} \
+"
+
+do_compile() {
+    export PATH="${STAGING_BINDIR_NATIVE}/python3-native:${PATH}"
+    export CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1
+
+    # Build G2L/V2L flavor (CFG_DT=y: NS DTB injection via U-Boot)
+    oe_runmake ${OPTEE_COMMON_FLAGS} \
+        PLATFORM_FLAVOR=g2l_smarc_2 \
+        CFG_DT=y \
+        O=${S}/out-g2l
+
+    # Build V2H flavor (CFG_DT=n: static DT node in kernel)
+    oe_runmake ${OPTEE_COMMON_FLAGS} \
+        PLATFORM_FLAVOR=v2h_evk_1 \
+        CFG_DT=n \
+        O=${S}/out-v2h
+}
+
+do_install() {
+    install -d ${D}/boot
+
+    install -m 0644 ${S}/out-g2l/core/tee-raw.bin  ${D}/boot/tee-${MACHINE}-g2l.bin
+    install -m 0644 ${S}/out-v2h/core/tee-raw.bin  ${D}/boot/tee-${MACHINE}-v2h.bin
+
+    install -d ${D}${includedir}/optee/export-user_ta
+    cp -aR ${S}/out-g2l/export-ta_arm64/* ${D}${includedir}/optee/export-user_ta/
+}
+
+do_deploy() {
+    install -d ${DEPLOYDIR}/target/images/atf
+
+    install -m 0644 ${D}/boot/tee-${MACHINE}-g2l.bin ${DEPLOYDIR}/target/images/atf/tee-${MACHINE}-g2l.bin
+    install -m 0644 ${D}/boot/tee-${MACHINE}-v2h.bin ${DEPLOYDIR}/target/images/atf/tee-${MACHINE}-v2h.bin
+}
+
+addtask deploy after do_install
+
+FILES:${PN} = "/boot"
+SYSROOT_DIRS += "/boot"
+FILES:${PN}-dev = "${includedir}/optee"
+INSANE_SKIP:${PN}-dev = "staticdev buildpaths"
+INSANE_SKIP:${PN} = "buildpaths"

--- a/recipes-docs/rz-cmn-readme/files/README.md
+++ b/recipes-docs/rz-cmn-readme/files/README.md
@@ -2149,6 +2149,73 @@ root@rz-cmn:~# uname -v
 #1 SMP PREEMPT_RT Thu Nov  6 09:54:14 UTC 2025
 ```
 
+#### 4.1.12. OP-TEE Trusted Execution Environment
+
+OP-TEE (Open Portable Trusted Execution Environment) provides a secure world environment running alongside Linux in the Normal World. The RZ CMN BSP supports open-source OP-TEE built from [Renesas-SST/rz_optee_os](https://github.com/Renesas-SST/rz_optee_os).
+
+Two firmware binaries are built per Yocto build run and packed into the FIP by `firmware_compile.py`:
+
+| Binary | SoC Family | Platform Flavor |
+| ------ | ---------- | --------------- |
+| `tee-rz-cmn-g2l.bin` | RZ/G2L, RZ/V2L | `g2l_smarc_2` — NS DTB injected via U-Boot (`CFG_DT=y`) |
+| `tee-rz-cmn-v2h.bin` | RZ/V2H | `v2h_evk_1` — static DT node in kernel (`CFG_DT=n`) |
+
+**Enable OP-TEE**
+
+1. Open `build/conf/local.conf` in the Yocto build environment.
+
+2. Uncomment (or add) the following line:
+
+    ```
+    # OP-TEE: Build open-source OP-TEE OS and include tee-supplicant in the image
+    ENABLE_SPD_OPTEE = "1"
+    ```
+
+3. Rebuild the image:
+
+    ```shell
+    bitbake core-image-minimal
+    ```
+
+    This will:
+    - Build both `tee-rz-cmn-g2l.bin` and `tee-rz-cmn-v2h.bin` from source.
+    - Pass `SPD=opteed` to TF-A so BL2 loads OP-TEE (BL32) from the FIP at boot.
+    - Include `optee-client` (`tee-supplicant`) in the root filesystem.
+
+4. Flash the new firmware using `firmware_compile.py`. The script automatically detects the correct `tee-*.bin` for each board from `flash_images.json` and packs it as `--tos-fw` in the FIP.
+
+After a successful boot, verify OP-TEE is running:
+
+```shell
+root@rz-cmn:~# ls /dev/tee*
+/dev/tee0  /dev/teepriv0
+```
+
+**Disable OP-TEE**
+
+1. Open `build/conf/local.conf`.
+
+2. Comment out or remove the `ENABLE_SPD_OPTEE` line:
+
+    ```
+    # ENABLE_SPD_OPTEE = "1"
+    ```
+
+3. Rebuild and reflash the image. BL2 will boot directly to BL33 (U-Boot) without loading a secure OS.
+
+**Optional: Enable Hardware Crypto (SCE)**
+
+For RZ/G2L and RZ/V2L boards, OP-TEE can use the hardware SCE (Secure Crypto Engine) driver. To enable:
+
+```
+ENABLE_SPD_OPTEE = "1"
+ENABLE_RZ_SCE    = "1"
+```
+
+> **Note:** `ENABLE_RZ_SCE` has no effect when `ENABLE_SPD_OPTEE = "0"`.
+
+---
+
 ### 4.2. RZ/G2L-SBC Yocto Features
 #### 4.2.1. 40-Pin IO Expansion Interface
 


### PR DESCRIPTION
Integrate open-source OP-TEE into the rz-cmn Yocto BSP as an opt-in feature. OP-TEE is disabled by default and enabled via `ENABLE_SPD_OPTEE = "1"` in `local.conf`.
